### PR TITLE
Redundancy

### DIFF
--- a/popper.py
+++ b/popper.py
@@ -68,14 +68,17 @@ def popper(experiment):
 
             # 3. Build constraints
             cons = set()
+
             # eliminate generalisations of clauses that contain logical redundancy
             for clause in tester.check_redundant_literal(program):
                 cons.update(constrainer.redundant_literal_constraint(clause))
+
             # eliminate generalisations of programs that contain logical redundancy
-            with experiment.duration('check_redundant_clause_tester'):
-                if tester.check_redundant_clause(program):
-                    cons.update(constrainer.generalisation_constraint(program))
-            cons.update(constrainer.build_constraints([(program, outcome)]))
+            if tester.check_redundant_clause(program):
+                cons.update(constrainer.generalisation_constraint(program))
+
+            # add other constraints
+            cons.update(constrainer.build_constraints(program, outcome))
 
             if experiment.args.debug:
                 print('Constraints:')

--- a/popper/core.py
+++ b/popper/core.py
@@ -46,7 +46,10 @@ class Literal:
             return x
 
     def __hash__(self):
-      return hash((self.predicate, self.arguments))
+        return hash((self.predicate, self.arguments))
+
+    def my_hash(self):
+        return hash((self.predicate, self.arguments))
 
     def to_code(self):
         return f'{self.predicate}({",".join(self.arguments)})'
@@ -129,7 +132,7 @@ class Clause:
 
     def to_code(self):
         return (
-            f'{self.head.to_code()} :- '
+            f'{self.head.to_code()}:- '
             f'{",".join([blit.to_code() for blit in self.body])}'
         )
 
@@ -138,6 +141,13 @@ class Clause:
         if self.head:
             return Clause(self.head.ground(assignment), ground_body, self.min_num)
         return Clause(None, ground_body, self.min_num)
+
+    def my_hash(self):
+        if self.head:
+            xs = (self.head.my_hash(), ) + tuple(lit.my_hash() for lit in self.body)
+            return hash((self.head.my_hash(), ) + tuple(lit.my_hash() for lit in self.body))
+        else:
+            return hash(tuple(lit.my_hash for lit in self.body))
 
 class Program:
     def __init__(self, clauses, before = defaultdict(set)):
@@ -152,6 +162,9 @@ class Program:
     def to_code(self):
         for clause in self.clauses:
             yield clause.to_code() + '.'
+
+    def my_hash(self):
+        return hash(tuple(clause.my_hash() for clause in self.clauses))
 
 class Constraint:
     def __init__(self, ctype, head, body):
@@ -201,5 +214,5 @@ class Constraint:
 
         x = f':- {", ".join(constraint_literals)}.'
         if self.head:
-            return f'{self.head} :- {x}'
+            return f'{self.head} {x}'
         return x

--- a/popper/log.py
+++ b/popper/log.py
@@ -40,23 +40,15 @@ class Experiment:
     def stats(self, program):
         total_exec_time = perf_counter() - self.exec_start
 
-        message = f'Total programs: {self.total_programs}\n\n'
+        message = f'Total programs: {self.total_programs}\n'
         total_op_time = 0
         for operation, durations in self.durations.items():
             called = len(durations)
             total = sum(durations)
             mean = sum(durations)/len(durations)
-            message += f'{operation.title()}\n'
-            message += f'Called: {called} times | Total: {total:0.5f}s | Mean: {mean:0.5f}s\n\n'
-
+            message += f'{operation.title()}: Called: {called} times | Total: {total:0.3f}s | Mean: {mean:0.4f}s\n'
             if operation != 'basic setup':
                 total_op_time += total
         message += f'Total operation time: {total_op_time:0.2f}s\n'
-        message += f'Total execution time: {total_exec_time:0.2f}s\n'
-
-        if program:
-            message += '\nProgram:'
-        else:
-            message += '\nNo program returned'
-
+        message += f'Total execution time: {total_exec_time:0.2f}s'
         print(message)

--- a/popper/test.pl
+++ b/popper/test.pl
@@ -63,3 +63,29 @@ minimal_test_neg(1):-
     neg(X),
     test_ex(X),!.
 minimal_test_neg(0).
+
+
+
+%% ==========
+
+subsumes(C,D) :- \+ \+ (copy_term(D,D2), numbervars(D2,0,_), subset(C,D2)).
+
+subset([], _D).
+subset([A|B], D):-
+    member(A, D),
+    subset(B,D).
+
+redundant_literal(C1):-
+    select(_,C1,C2),
+    subsumes(C1,C2),!.
+
+redundant_clause(P1):-
+    select(C1,P1,P2),
+    member(C2,P2),
+    subsumes(C1,C2),!.
+
+%% reduce(C1,C2):-
+%%     select(_,C1,C3),
+%%     subsumes(C1,C3),!,
+%%     reduce(C3,C2).
+%% reduce(C,C).


### PR DESCRIPTION
This change helps address issue #7 

The solution is not optimal because we reason about redundancy in Prolog after generating a program, rather than with the ASP solver.

The solution checks whether (i) a program contains a clause which contains redundancy (i.e. a redundant literal), and (ii) whether a clause in a program subsumes another (with variable renaming). 

I think it is still a worthwhile change as it leads to more pruning. 