### PR TITLE
Stats and logging improvements

### DIFF
--- a/popper.py
+++ b/popper.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 
-from popper.util import Settings, Stats, timeout
+import logging
+import sys
+from popper.util import Settings, Stats, timeout, parse_settings
 from popper.asp import ClingoGrounder, ClingoSolver
 from popper.tester import Tester
 from popper.constrain import Constrain
 from popper.generate import generate_program
-from popper.core import Literal, Grounding, Clause
-import multiprocessing
-import threading
+from popper.core import Grounding, Clause
 
 class Outcome:
     ALL = 'all'
@@ -29,7 +29,7 @@ OUTCOME_TO_CONSTRAINTS = {
         (Outcome.NONE, Outcome.SOME) : (Con.SPECIALISATION, Con.REDUNDANCY, Con.GENERALISATION)
     }
 
-def ground_rules(grounder, max_clauses, max_vars, clauses):
+def ground_rules(stats, grounder, max_clauses, max_vars, clauses):
     out = set()
     for clause in clauses:
         (head, body) = clause
@@ -42,11 +42,10 @@ def ground_rules(grounder, max_clauses, max_vars, clauses):
         # ground the clause for each variable assignment
         for assignment in assignments:
             out.add(Grounding.ground_clause((head, body), assignment))
-    return out
+    
+    stats.register_ground_rules(out)
 
-def pprint(program):
-    for clause in program:
-        print(Clause.to_code(clause))
+    return out
 
 def decide_outcome(conf_matrix):
     tp, fn, tn, fp = conf_matrix
@@ -66,7 +65,7 @@ def decide_outcome(conf_matrix):
 
     return (positive_outcome, negative_outcome)
 
-def build_rules(settings, constrainer, tester, program, before, min_clause, outcome):
+def build_rules(settings, stats, constrainer, tester, program, before, min_clause, outcome):
     (positive_outcome, negative_outcome) = outcome
     # RM: If you don't use these two lines you need another three entries in the OUTCOME_TO_CONSTRAINTS table (one for every positive outcome combined with negative outcome ALL).
     if negative_outcome == Outcome.ALL:
@@ -109,11 +108,7 @@ def build_rules(settings, constrainer, tester, program, before, min_clause, outc
                         for x in constrainer.redundancy_constraint([rule], before, min_clause):
                             rules.add(x)
 
-    if settings.debug:
-        print('Rules:')
-        for rule in rules:
-            Constrain.print_constraint(rule)
-        print()
+    stats.register_rules(rules)
 
     return rules
 
@@ -123,17 +118,7 @@ def calc_score(conf_matrix):
     (tp, fn, tn, fp) = conf_matrix
     return tp + tn
 
-def print_conf_matrix(conf_matrix):
-    tp, fn, tn, fp = conf_matrix
-    precision = 'n/a'
-    if (tp+fp) > 0:
-        precision = f'{tp / (tp+fp):0.2f}'
-    recall = 'n/a'
-    if (tp+fn) > 0:
-        recall = f'{tp / (tp+fn):0.2f}'
-    print(f'Precision:{precision}, Recall:{recall}, TP:{tp}, FN:{fn}, TN:{tn}, FP:{fp}')
-
-def popper(settings, stats, args):
+def popper(settings, stats):
     solver = ClingoSolver(settings)
     tester = Tester(settings)
     settings.num_pos, settings.num_neg = len(tester.pos), len(tester.neg)
@@ -142,9 +127,9 @@ def popper(settings, stats, args):
     best_score = None
 
     for size in range(1, settings.max_literals + 1):
-        if settings.debug:
-            print(f'{"*" * 20} MAX LITERALS: {size} {"*" * 20}')
+        stats.update_num_literals(size)
         solver.update_number_of_literals(size)
+
         while True:
             # GENERATE HYPOTHESIS
             with stats.duration('generate'):
@@ -153,11 +138,7 @@ def popper(settings, stats, args):
                     break
                 (program, before, min_clause) = generate_program(model)
 
-            if settings.debug:
-                print(f'Program {stats.total_programs}:')
-                pprint(program)
-
-            stats.total_programs +=1
+            stats.register_program(program)
 
             # TEST HYPOTHESIS
             with stats.duration('test'):
@@ -168,43 +149,38 @@ def popper(settings, stats, args):
             # UPDATE BEST PROGRAM
             if best_score == None or score > best_score:
                 best_score = score
-                args[PROG_KEY] = (program, conf_matrix)
 
                 if outcome == (Outcome.ALL, Outcome.NONE):
-                    return
+                    stats.register_solution(program, conf_matrix)
+                    return stats.solution.code
 
-                if settings.info:
-                    print(f'NEW BEST PROG {stats.total_programs}:')
-                    pprint(program)
-                    print_conf_matrix(conf_matrix)
-                    print('')
+                stats.register_best_program(program, conf_matrix)
 
             # BUILD RULES
             with stats.duration('build_rules'):
-                rules = build_rules(settings, constrainer, tester, program, before, min_clause, outcome)
+                rules = build_rules(settings, stats, constrainer, tester, program, before, min_clause, outcome)
 
             # GROUND RULES
             with stats.duration('ground'):
-                rules = ground_rules(grounder, solver.max_clauses, solver.max_vars, rules)
+                rules = ground_rules(stats, grounder, solver.max_clauses, solver.max_vars, rules)
 
             # UPDATE SOLVER
             with stats.duration('add'):
                 solver.add_ground_clauses(rules)
 
-    print('NO MORE SOLUTIONS')
-    return
+    stats.register_completion()
+    return stats.best_program.code if stats.best_program else None
 
 if __name__ == '__main__':
-    settings = Settings()
+    settings = parse_settings()
+    logging.basicConfig(
+        level=logging.DEBUG if settings.debug else logging.INFO,
+        stream=sys.stderr,
+        format='%(message)s')
     stats = Stats()
-    args = {}
-    timeout(popper, (settings, stats, args), timeout_duration=int(settings.timeout))
+    timeout(popper, (settings, stats), timeout_duration=int(settings.timeout))
 
-    if PROG_KEY in args:
-        print(f'BEST PROG {stats.total_programs}:')
-        (program, conf_matrix) = args[PROG_KEY]
-        pprint(program)
-        print_conf_matrix(conf_matrix)
-        print('')
+    stats.log_final_result()
+
     if settings.stats:
         stats.show()

--- a/popper.py
+++ b/popper.py
@@ -177,7 +177,7 @@ if __name__ == '__main__':
         level=logging.DEBUG if settings.debug else logging.INFO,
         stream=sys.stderr,
         format='%(message)s')
-    stats = Stats()
+    stats = Stats(log_best_programs=settings.info)
     timeout(popper, (settings, stats), timeout_duration=int(settings.timeout))
 
     stats.log_final_result()

--- a/popper/asp.py
+++ b/popper/asp.py
@@ -124,8 +124,7 @@ class ClingoSolver():
             self.solver.add('alan', [], alan.read())
 
         # load mode file
-        with open(settings.bias_file) as biasfile:
-            self.solver.add('bias', [], biasfile.read())
+        self.solver.add('bias', [], settings.bias_string)
 
         # Reset number of literals and clauses because size_in_literals literal within Clingo is reset by loading Alan? (bottom two).
         self.solver.add('invented', ['predicate', 'arity'], '#external invented(pred,arity).')

--- a/popper/constrain.py
+++ b/popper/constrain.py
@@ -197,7 +197,7 @@ class Constrain:
             yield (None, tuple(literals))
 
     @staticmethod
-    def print_constraint(con):
+    def format_constraint(con):
         (head, body) = con
         constraint_literals = []
         for constobj in body:
@@ -221,4 +221,4 @@ class Constrain:
         x = f':- {", ".join(constraint_literals)}.'
         if head:
             x = f'{head} {x}'
-        print(x)
+        return x

--- a/popper/util.py
+++ b/popper/util.py
@@ -27,6 +27,7 @@ def parse_args():
     parser.add_argument('--max-literals', type=int, default=MAX_LITERALS, help='Maximum number of literals allowed in program')
     # parser.add_argument('--max-solutions', type=int, default=MAX_SOLUTIONS, help='Maximum number of solutions to print')
     parser.add_argument('--test-all', default=TEST_ALL, action='store_true', help='Test all examples')
+    parser.add_argument('--info', default=DEBUG, action='store_true', help='Print best programs so far to stderr')
     parser.add_argument('--debug', default=DEBUG, action='store_true', help='Print debugging information to stderr')
     parser.add_argument('--stats', default= STATS, action='store_true', help='Print statistics at end of execution')
     parser.add_argument('--functional-test', default=FUNCTIONAL_TEST, action='store_true', help='Run custom functional test')
@@ -77,6 +78,7 @@ def parse_settings():
         bias_string,
         args.ex_file if args.ex_file else ex_file,
         args.bk_file if args.bk_file else bk_file,
+        info = args.info,
         debug = args.debug,
         stats = args.stats,
         eval_timeout = args.eval_timeout,
@@ -93,6 +95,7 @@ class Settings:
             bias_string, 
             ex_file,
             bk_file,
+            info = False,
             debug = False,
             stats = False,
             eval_timeout = EVAL_TIMEOUT,
@@ -106,6 +109,7 @@ class Settings:
         self.bias_string = bias_string
         self.ex_file = ex_file
         self.bk_file = bk_file
+        self.info = info
         self.debug = debug
         self.stats = stats
         self.eval_timeout = eval_timeout
@@ -131,7 +135,7 @@ def format_conf_matrix(conf_matrix):
 
 class Stats:
     def __init__(self,
-                    log_level=logging.INFO,
+                    log_best_programs=False,
                     num_literals = 0,
                     total_programs = 0,
                     total_rules = 0,
@@ -144,6 +148,7 @@ class Stats:
         self.exec_start = perf_counter()
         self.logger = logging.getLogger("popper")
 
+        self.log_best_programs = log_best_programs
         self.num_literals = num_literals
         self.total_programs = total_programs
         self.total_rules = total_rules
@@ -181,9 +186,10 @@ class Stats:
     def register_best_program(self, program, conf_matrix):
         prog_stats = self.make_program_stats(program, conf_matrix)
         self.best_programs.append(prog_stats)
-        self.logger.info(f'NEW BEST PROG {self.total_programs}:')
-        self.logger.info(prog_stats.code)
-        self.logger.info(format_conf_matrix(conf_matrix))
+        if self.log_best_programs:
+            self.logger.info(f'NEW BEST PROG {self.total_programs}:')
+            self.logger.info(prog_stats.code)
+            self.logger.info(format_conf_matrix(conf_matrix))
 
     def log_final_result(self):
         if self.solution:

--- a/popper/util.py
+++ b/popper/util.py
@@ -1,7 +1,12 @@
 import signal
 import argparse
+import os
+import logging
+import copy
 from time import perf_counter
 from contextlib import contextmanager
+from .core import Clause
+from .constrain import Constrain
 
 TIMEOUT=600
 EVAL_TIMEOUT=0.001
@@ -23,10 +28,12 @@ def parse_args():
     # parser.add_argument('--max-solutions', type=int, default=MAX_SOLUTIONS, help='Maximum number of solutions to print')
     parser.add_argument('--test-all', default=TEST_ALL, action='store_true', help='Test all examples')
     parser.add_argument('--debug', default=DEBUG, action='store_true', help='Print debugging information to stderr')
-    parser.add_argument('--info', default=INFO, action='store_true', help='Print useful info information to stderr')
     parser.add_argument('--stats', default= STATS, action='store_true', help='Print statistics at end of execution')
     parser.add_argument('--functional-test', default=FUNCTIONAL_TEST, action='store_true', help='Run custom functional test')
     parser.add_argument('--clingo-args', type=str, default=CLINGO_ARGS, help='Arguments to pass to Clingo')
+    parser.add_argument('--ex-file', type=str, default='', help='Filename for the examples')
+    parser.add_argument('--bk-file', type=str, default='', help='Filename for the background knowledge')
+    parser.add_argument('--bias-file', type=str, default='', help='Filename for the bias')
     return parser.parse_args()
 
 def timeout(func, args=(), kwargs={}, timeout_duration=1, default=None):
@@ -48,30 +55,205 @@ def timeout(func, args=(), kwargs={}, timeout_duration=1, default=None):
 
     return result
 
+def load_kbpath(kbpath, bias_filename):
+    if not bias_filename:
+        bias_filename = fix_path(kbpath, 'bias.pl')
+
+    with open(bias_filename, "r") as bias_file:
+        bias_string = bias_file.read()
+
+    return (fix_path(kbpath, "bk.pl"), fix_path(kbpath, "exs.pl"), bias_string)
+    
+def fix_path(kbpath, filename):
+    full_filename = os.path.join(kbpath, filename)
+    return full_filename.replace('\\', '\\\\') if os.name == 'nt' else full_filename
+
+def parse_settings():
+    args = parse_args()
+    
+    (bk_file, ex_file, bias_string) = load_kbpath(args.kbpath, args.bias_file)
+
+    return Settings(
+        bias_string,
+        args.ex_file if args.ex_file else ex_file,
+        args.bk_file if args.bk_file else bk_file,
+        debug = args.debug,
+        stats = args.stats,
+        eval_timeout = args.eval_timeout,
+        test_all = args.test_all,
+        timeout = args.timeout,
+        max_literals = args.max_literals,
+        clingo_args= [] if not args.clingo_args else args.clingo_args.split(' '),
+        max_solutions = MAX_SOLUTIONS, #args.max_solutions,
+        functional_test = args.functional_test
+    )
+
+class Settings:
+    def __init__(self,
+            bias_string, 
+            ex_file,
+            bk_file,
+            debug = False,
+            stats = False,
+            eval_timeout = EVAL_TIMEOUT,
+            test_all = False,
+            timeout = TIMEOUT,
+            max_literals = MAX_LITERALS,
+            clingo_args = CLINGO_ARGS,
+            max_solutions = MAX_SOLUTIONS,
+            functional_test = False):
+            
+        self.bias_string = bias_string
+        self.ex_file = ex_file
+        self.bk_file = bk_file
+        self.debug = debug
+        self.stats = stats
+        self.eval_timeout = eval_timeout
+        self.test_all = test_all
+        self.timeout = timeout
+        self.max_literals = max_literals
+        self.clingo_args = clingo_args
+        self.max_solutions = max_solutions
+        self.functional_test = functional_test
+
+def format_program(program):
+    return "\n".join(Clause.to_code(clause) for clause in program)
+
+def format_conf_matrix(conf_matrix):
+    tp, fn, tn, fp = conf_matrix
+    precision = 'n/a'
+    if (tp+fp) > 0:
+        precision = f'{tp / (tp+fp):0.2f}'
+    recall = 'n/a'
+    if (tp+fn) > 0:
+        recall = f'{tp / (tp+fn):0.2f}'
+    return f'Precision:{precision}, Recall:{recall}, TP:{tp}, FN:{fn}, TN:{tn}, FP:{fp}\n'
+
 class Stats:
-    def __init__(self):
-        self.total_programs = 0
-        self.durations = {}
+    def __init__(self,
+                    log_level=logging.INFO,
+                    num_literals = 0,
+                    total_programs = 0,
+                    total_rules = 0,
+                    total_ground_rules = 0,
+                    durations = None,
+                    final_exec_time = 0,
+                    stages = None,
+                    best_programs = None,
+                    solution = None):
         self.exec_start = perf_counter()
+        self.logger = logging.getLogger("popper")
+
+        self.num_literals = num_literals
+        self.total_programs = total_programs
+        self.total_rules = total_rules
+        self.total_ground_rules = total_ground_rules
+        self.durations = {} if not durations else durations
+        self.final_exec_time = final_exec_time
+        self.stages = [] if not stages else stages
+        self.best_programs = [] if not best_programs else best_programs
+        self.solution = solution
 
     def __enter__(self):
         return self
 
+    def update_num_literals(self, size):
+        prev_stage = self.stages[-1] if self.stages else None
+        programs_tried = self.total_programs - prev_stage.total_programs if prev_stage else 0
+
+        total_exec_time = self.total_exec_time()
+        exec_time = total_exec_time - prev_stage.total_exec_time if prev_stage else 0
+        
+        self.stages.append(Stage(size, self.total_programs, programs_tried, total_exec_time, exec_time))
+
+        self.logger.debug(f'Programs tried: {programs_tried} Exec Time: {exec_time:0.3f}s Total Exec Time: {total_exec_time:0.3f}s\n')
+
+        self.logger.debug(f'{"*" * 20} MAX LITERALS: {size} {"*" * 20}')
+
+        self.num_literals = size
+    
+    def register_program(self, program):
+        self.total_programs +=1
+        
+        self.logger.debug(f'Program {self.total_programs}:')
+        self.logger.debug(format_program(program))
+    
+    def register_best_program(self, program, conf_matrix):
+        prog_stats = self.make_program_stats(program, conf_matrix)
+        self.best_programs.append(prog_stats)
+        self.logger.info(f'NEW BEST PROG {self.total_programs}:')
+        self.logger.info(prog_stats.code)
+        self.logger.info(format_conf_matrix(conf_matrix))
+
+    def log_final_result(self):
+        if self.solution:
+            prog_stats = self.solution
+        elif self.best_programs:
+            prog_stats = self.best_programs[-1]
+        else:
+            self.logger.info('NO PROGRAMS FOUND')
+            return
+
+        self.logger.info(f'\nBEST PROG {self.total_programs}:')
+        self.logger.info(prog_stats.code)
+        self.logger.info(format_conf_matrix(prog_stats.conf_matrix))
+
+    def make_program_stats(self, program, conf_matrix):
+        code = format_program(program)
+        return ProgramStats(code, conf_matrix, self.total_exec_time(), self.duration_summary())
+
+    def register_solution(self, program, conf_matrix):
+        prog_stats = self.make_program_stats(program, conf_matrix)
+        self.solution = prog_stats
+
+    def register_completion(self):
+        self.logger.info('NO MORE SOLUTIONS')
+        self.final_exec_time = self.total_exec_time()
+
+    def register_rules(self, rules):
+        self.logger.debug('Rules:')
+        for rule in rules:
+            self.logger.debug(Constrain.format_constraint(rule))
+        self.logger.debug('\n')
+
+        self.total_rules += len(rules)
+    
+    def register_ground_rules(self, rules):
+        self.total_ground_rules += len(rules)
+
+    @property
+    def best_program(self):
+        if self.solution:
+            return self.solution
+        if self.best_programs:
+            return self.best_programs[-1]
+        return None
+
+    def total_exec_time(self):
+        return perf_counter() - self.exec_start
+
     def show(self):
-        total_exec_time = perf_counter() - self.exec_start
         message = f'Total programs: {self.total_programs}\n'
         total_op_time = 0
+        for summary in self.duration_summary():
+            message += f'{summary.operation}:\n\tCalled: {summary.called} times \t ' + \
+                       f'Total: {summary.total:0.2f} \t Mean: {summary.mean:0.3f} \t ' + \
+                       f'Max: {summary.maximum:0.3f}\n'
+            if summary.operation != 'basic setup':
+                total_op_time += summary.total
+        message += f'Total operation time: {total_op_time:0.2f}s\n'
+        message += f'Total execution time: {self.total_exec_time():0.2f}s'
+        self.logger.info(message)
+
+    def duration_summary(self):
+        summary = []
         for operation, durations in self.durations.items():
             called = len(durations)
             total = sum(durations)
             mean = sum(durations)/len(durations)
-            max_ = max(durations)
-            message += f'{operation.title()}:\n\tCalled: {called} times \t Total: {total:0.2f} \t Mean: {mean:0.3f} \t Max: {max_:0.3f}\n'
-            if operation != 'basic setup':
-                total_op_time += total
-        message += f'Total operation time: {total_op_time:0.2f}s\n'
-        message += f'Total execution time: {total_exec_time:0.2f}s'
-        print(message)
+            maximum = max(durations)
+            summary.append(DurationSummary(operation.title(), called, total, mean, maximum))
+        return summary
 
     @contextmanager
     def duration(self, operation):
@@ -87,24 +269,29 @@ class Stats:
             else:
                 self.durations[operation].append(duration)
 
-class Settings:
-    def __init__(self, cmd_line=True):
-        if cmd_line:
-            args = parse_args()
-            self.debug = args.debug
-            self.info = args.info
-            self.stats = args.stats
-            self.kbpath = args.kbpath
-            if self.kbpath[-1] != '/':
-                self.kbpath += '/'
-            self.bias_file = self.kbpath + 'bias.pl'
-            self.ex_file = self.kbpath + 'exs.pl'
-            self.bk_file = self.kbpath + 'bk.pl'
-            self.eval_timeout = args.eval_timeout
-            self.test_all = args.test_all
-            self.timeout = args.timeout
-            self.max_literals = args.max_literals
-            self.clingo_args = args.clingo_args
-            # self.max_solutions = args.max_solutions
-            self.functional_test = args.functional_test
-            self.clingo_args = [] if not args.clingo_args else args.clingo_args.split(' ')
+class Stage:
+    def __init__(self, num_literals, total_programs, programs, total_exec_time, exec_time):
+        self.num_literals = num_literals
+        self.total_programs = total_programs
+        self.programs = programs
+        self.total_exec_time = total_exec_time
+        self.exec_time = exec_time
+
+class ProgramStats:
+    def __init__(self, code, conf_matrix, total_exec_time, durations):
+        self.code = code
+        self.conf_matrix = conf_matrix
+        self.total_exec_time = total_exec_time
+        self.durations = durations
+
+        _, fn, _, fp = conf_matrix
+        
+        self.is_solution = fn == fp == 0
+
+class DurationSummary:
+    def __init__(self, operation, called, total, mean, maximum):
+        self.operation = operation
+        self.called = called
+        self.total = total
+        self.mean = mean
+        self.maximum = maximum


### PR DESCRIPTION
This is a first step toward two simultaneous goals

1. Make it easy to implement a parallel experiment runner for Popper
2. Make Popper easier to use programatically from within another
Python application.

The major changes here are:
1. Configure the Popper loop to store information about its execution
in the Stats object. The Stats object can then be serialized or analyzed
programatically.
2. Add arguments to the Settings initializer so a Settings object can be
created without argparse.
3. Perform all logging using python's logging framework rather than
print(). This makes it easy for other applications to tune how the
logging happens, set the log level, etc.

There should be no changes to command line Popper besides a very small
amount of extra memory usage.

For goal 1, future work will include an experiment runner in a
separate repo.

For goal 2, we probably want to add a setup.py file to build a .whl file
from Popper and publish it to PyPi.