### PR TITLE
Add --stats-file for experimentation framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ If you use Popper, please cite the paper: Andrew Cropper and Rolf Morel. [Learni
 
 [pyswip](https://pypi.org/project/pyswip/)
 
+The following will install all requirements on Ubuntu:
+
+```bash
+sudo apt-add-repository ppa:swi-prolog/stable
+sudo add-apt-repository ppa:potassco/stable
+sudo apt-get update
+sudo apt-get install swi-prolog
+sudo apt-get install clingo
+sudo apt-get install python3-pip
+python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+```
 
 # Command line usage
 
@@ -262,3 +274,4 @@ To run with a maximum example testing time use the flag `--eval-timeout` (`setti
 To allow non-Datalog clauses, where a variable in the head need not appear in the body, add ``non_datalog.` to your bias file.
 
 To allow singleton variables (variables that only appear once in a clause), add `allow_singletons.` to your bias file.
+

--- a/popper.py
+++ b/popper.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-
-from popper.util import Settings, parse_settings
-from popper.loop import learn_solution, show_hspace
+from popper.loop import show_hspace, learn_solution
+from popper.util import parse_settings
 
 if __name__ == '__main__':
     settings = parse_settings()

--- a/popper/loop.py
+++ b/popper/loop.py
@@ -175,7 +175,7 @@ def show_hspace(settings):
     ClingoSolver.get_hspace(settings, f)
 
 def learn_solution(settings):
-    stats = Stats(log_best_programs=settings.info)
+    stats = Stats(log_best_programs=settings.info, stats_file=settings.stats_file)
     log_level = logging.DEBUG if settings.debug else logging.INFO
     logging.basicConfig(level=log_level, stream=sys.stderr, format='%(message)s')
     timeout(popper, (settings, stats), timeout_duration=int(settings.timeout))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyswip
+clingo


### PR DESCRIPTION
This change adds the --stats-file command line option to Popper which
enables writing the output of the Stats object to a JSON file.

The change is necessary to support the experimentation framework in
the accompanying ilp-experiments repository.

I also made some slight changes to the format of the Stats object to make it
more convenient. This shouldn't affect anything since it wasn't really
being used prior to this change.