### PR TITLE
Add warning when global timeout occurs

### DIFF
--- a/popper/util.py
+++ b/popper/util.py
@@ -46,6 +46,7 @@ def timeout(func, args=(), kwargs={}, timeout_duration=1, default=None):
     try:
         result = func(*args, **kwargs)
     except TimeoutError as exc:
+        logging.warning(f'% hgalted execution after overall timeout of {timeout_duration} seconds')
         result = default
     finally:
         signal.alarm(0)


### PR DESCRIPTION
I was caught unawares when the 600s global timeout silently interrupted my computation. Adding a warning message would at least alert users to what has happened in the execution of their problem.