### PR TITLE
Add script to directly execute popper

### DIFF
--- a/bin/popper-ilp
+++ b/bin/popper-ilp
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from popper.util import Settings, print_prog_score
+from popper.loop import learn_solution
+
+if __name__ == '__main__':
+    settings = Settings(cmd_line=True)
+    prog, score, stats = learn_solution(settings)
+    if prog != None:
+        print_prog_score(prog, score)
+    else:
+        print('NO SOLUTION')
+    if settings.show_stats:
+        stats.show()

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,9 @@ setuptools.setup(
     install_requires=[
         'clingo',
         'pyswip'
-    ],                                             
+    ],
     url="https://github.com/logic-and-learning-lab/Popper",
+    scripts=['bin/popper-ilp'],
     packages=setuptools.find_packages()
     # classifiers=(                                 # Classifiers help people find your
         # "Programming Language :: Python :: 3"    # projects. See all possible classifiers


### PR DESCRIPTION
This fixes a annoying issue for me when executing popper:

Since the name of the python file "popper.py" and the module for popper is also named popper, it is unpredictable to execute popper after installing it with the setup.py as it does not know which popper to use. With the popper executable it will always use the script that is installed with the setup.py and one does not need to search for the path where it is installed again and can just use `popper-ilp`

A note here also: Calling the executable popper will fail as it then wants to import itself