### PR TITLE
Fix missing `noisy` parameter in popper-ilp script

### DIFF
--- a/bin/popper-ilp
+++ b/bin/popper-ilp
@@ -7,7 +7,7 @@ if __name__ == '__main__':
     settings = Settings(cmd_line=True)
     prog, score, stats = learn_solution(settings)
     if prog != None:
-        print_prog_score(prog, score)
+        print_prog_score(prog, score, settings.noisy)
     else:
         print('NO SOLUTION')
     if settings.show_stats:


### PR DESCRIPTION
The function `print_prog_score`  has an additional `noisy` parameter, which is missing in the `popper-ilp` script.

Without this fix, for pip-installed Popper, a `TypeError` is thrown at the end of the solver call:

```
$ python popper-ilp examples/zendo1
11:00:54 Generating programs of size: 2
11:00:54 Generating programs of size: 3
11:00:54 Generating programs of size: 4
11:00:54 Generating programs of size: 5
[...]
11:00:59 ********************
11:00:59 New best hypothesis:
11:00:59 tp:20 fn:0 tn:20 fp:0 size:26
11:00:59 zendo(A):- piece(A,B),contact(B,C),upright(C),red(C).
11:00:59 zendo(A):- piece(A,B),contact(B,C),rhs(C),red(C).
11:00:59 zendo(A):- piece(A,B),contact(B,C),lhs(C),red(C).
11:00:59 zendo(A):- piece(A,B),contact(B,C),lhs(B),red(C).
11:00:59 zendo(A):- piece(A,C),contact(C,B),coord1(B,D),medium(D),red(B).
11:00:59 ********************
Traceback (most recent call last):
  File "/home/thofmann/.local/share/virtualenvs/rule-learning-gTpM-L_F/bin/popper-ilp", line 10, in <module>
    print_prog_score(prog, score)
TypeError: print_prog_score() missing 1 required positional argument: 'noisy'
```

I wonder whether there is a better to way to do this that avoids the duplicate code in the main script and the script in `bin/popper-ilp` but for now, this fixes the issue.