### PR TITLE
Fix error in try..except

### DIFF
--- a/popper/tester.py
+++ b/popper/tester.py
@@ -421,8 +421,9 @@ class Tester():
                     pointless.add((p, pa))
                     # print(p, pa)
                     missing.add(p)
-            except Err:
-                print(Err)
+            except Exception as Err:
+                print(f"Error in find_pointless_relations: {Err}")
+                settings.logger.error(f"Error in find_pointless_relations: {Err}")
                 return pointless
 
         for p, pa in settings.body_preds:


### PR DESCRIPTION
There was a syntax error (I think) that would cause python never to print an error message.

Stumbled over this while trying to debug problem with an unsatisfiable learning domain.