### PR TITLE
Add GitLab and GitHub CI tests

### DIFF
--- a/.github/workflows/prt-test.yml
+++ b/.github/workflows/prt-test.yml
@@ -1,0 +1,30 @@
+name: Run PRT tests on Popper
+on: [push]
+jobs:
+  prt-test:
+    runs-on: ubuntu-latest
+    container: rpgoldman/popper-prt:latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: setup
+        run: python -m pip install --break-system-packages --root-user-action=ignore $GITHUB_WORKSPACE
+      - name: do_tests
+        run: |
+          cd /popper-prt
+          export PATH="/prt:${PATH}"
+          POPPER_PYTHON=`which python` POPPER_DIR=${GITHUB_WORKSPACE} MAXPARALLEL=16 ./parallel-prt.sh
+      - name: move_results
+        if: always()
+        run: |
+          cd /popper-prt
+          mv results ${GITHUB_WORKSPACE}
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prt-results
+          path: results/*

--- a/.github/workflows/prt-test.yml
+++ b/.github/workflows/prt-test.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           cd /popper-prt
           export PATH="/prt:${PATH}"
-          POPPER_PYTHON=`which python` POPPER_DIR=${GITHUB_WORKSPACE} MAXPARALLEL=16 ./parallel-prt.sh
+          POPPER_PYTHON=`which python` POPPER_DIR=${GITHUB_WORKSPACE} MAXPARALLEL=4 ./parallel-prt.sh
       - name: move_results
         if: always()
         run: |

--- a/.github/workflows/prt-test.yml
+++ b/.github/workflows/prt-test.yml
@@ -12,6 +12,8 @@ jobs:
           python-version: '3.12'
       - name: setup
         run: python -m pip install --break-system-packages --root-user-action=ignore $GITHUB_WORKSPACE
+      - name: check-cpus
+        run: lscpu
       - name: do_tests
         run: |
           cd /popper-prt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,42 @@
+# This file is a template, and might need editing before it works on your project.
+# This is a sample GitLab CI/CD configuration file that should run without any modifications.
+# It demonstrates a basic 3 stage CI/CD pipeline. Instead of real tests or scripts,
+# it uses echo commands to simulate the pipeline execution.
+#
+# A pipeline is composed of independent jobs that run scripts, grouped into stages.
+# Stages run in sequential order, but jobs within stages run in parallel.
+#
+# For more information, see: https://docs.gitlab.com/ee/ci/yaml/index.html#stages
+#
+# You can copy and paste this template into a new `.gitlab-ci.yml` file.
+# You should not add this template to an existing `.gitlab-ci.yml` file by using the `include:` keyword.
+#
+# To contribute improvements to CI/CD templates, please follow the Development guide at:
+# https://docs.gitlab.com/ee/development/cicd/templates.html
+# This specific template is located at:
+# https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Getting-Started.gitlab-ci.yml
+
+stages:          # List of stages for jobs, and their order of execution
+  - test
+
+prt-test:
+  tags:
+    - docker
+  stage: test
+  image: rpgoldman/popper-prt:latest
+  variables:
+      POPPER_DIR: $CI_PROJECT_DIR
+  artifacts:
+    paths:
+      - results/*
+    expire_in: 30 days
+    when: always
+  script:
+    - pip install --break-system-packages .
+    - cd /popper-prt
+    - export PATH="/prt:${PATH}"
+    # - which timestamp
+    - MAXPARALLEL=16 ./parallel-prt.sh
+  after_script:
+    - cd /popper-prt
+    - mv results ${CI_PROJECT_DIR}

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setuptools.setup(
         'clingo',
         'bitarray',
         'janus_swi',
-        'python-sat'
+        'python-sat',
+        'setuptools',
     ],
     url="https://github.com/logic-and-learning-lab/Popper",
     scripts=['bin/popper-ilp'],


### PR DESCRIPTION
These two tests aim to do the same thing.  The GitLab actions run on SIFT's local GitLab repo, and the GitHub actions are intended to run on GitHub.

The tests use SIFT's `prt` regression test framework and run on the examples distributed with Popper.  `prt` is had in the Docker image.  The Docker image is built from the `popper-prt` repo, the source for which we will make available.