### PR TITLE
replace deprecated `pkg_resources` with `importlib.resources`

### DIFF
--- a/popper/bkcons.py
+++ b/popper/bkcons.py
@@ -2,7 +2,6 @@ import clingo
 import clingo.script
 import numbers
 import operator
-import pkg_resources
 import time
 from . util import rule_is_recursive, format_rule, Constraint, order_prog, Literal, suppress_stdout_stderr
 from clingo import Function, Number, Tuple_
@@ -682,7 +681,7 @@ def deduce_bk_cons(settings, tester):
         bk = f.read()
 
 
-    # cons = pkg_resources.resource_string(__name__, "lp/cons.pl").decode()
+    # cons = resources.files(__name__).joinpath("lp/cons.pl").read_text()
     bk = bk.replace('\\+','not')
 
     new_props1, new_cons1 = build_props(settings, arities, tester)

--- a/popper/bkcons.py
+++ b/popper/bkcons.py
@@ -681,7 +681,7 @@ def deduce_bk_cons(settings, tester):
         bk = f.read()
 
 
-    # cons = resources.files(__name__).joinpath("lp/cons.pl").read_text()
+    # cons = resources.files(__package__).joinpath("lp/cons.pl").read_text()
     bk = bk.replace('\\+','not')
 
     new_props1, new_cons1 = build_props(settings, arities, tester)

--- a/popper/gen2.py
+++ b/popper/gen2.py
@@ -3,7 +3,7 @@ import re
 import clingo
 import numbers
 import clingo.script
-import pkg_resources
+from importlib import resources
 from . util import Constraint, Literal
 from clingo import Function, Number, Tuple_
 from itertools import permutations
@@ -39,7 +39,7 @@ class Generator:
         self.pruned_sizes = set()
 
         encoding = []
-        alan = pkg_resources.resource_string(__name__, "lp/alan.pl").decode()
+        alan = resources.files(__name__).joinpath("lp/alan.pl").read_text()
         encoding.append(alan)
 
         with open(settings.bias_file) as f:

--- a/popper/gen2.py
+++ b/popper/gen2.py
@@ -39,7 +39,7 @@ class Generator:
         self.pruned_sizes = set()
 
         encoding = []
-        alan = resources.files(__name__).joinpath("lp/alan.pl").read_text()
+        alan = resources.files(__package__).joinpath("lp/alan.pl").read_text()
         encoding.append(alan)
 
         with open(settings.bias_file) as f:

--- a/popper/gen3.py
+++ b/popper/gen3.py
@@ -7,7 +7,7 @@ import clingo
 import operator
 import numbers
 import clingo.script
-import pkg_resources
+from importlib import resources
 from collections import defaultdict
 from . util import rule_is_recursive, Constraint, Literal
 clingo.script.enable_python()
@@ -54,7 +54,7 @@ class Generator:
         self.new_ground_cons = set()
 
         encoding = []
-        alan = pkg_resources.resource_string(__name__, "lp/alan-old.pl").decode()
+        alan = resources.files(__name__).joinpath("lp/alan-old.pl").read_text()
         encoding.append(alan)
 
         with open(settings.bias_file) as f:

--- a/popper/gen3.py
+++ b/popper/gen3.py
@@ -54,7 +54,7 @@ class Generator:
         self.new_ground_cons = set()
 
         encoding = []
-        alan = resources.files(__name__).joinpath("lp/alan-old.pl").read_text()
+        alan = resources.files(__package__).joinpath("lp/alan-old.pl").read_text()
         encoding.append(alan)
 
         with open(settings.bias_file) as f:

--- a/popper/generate.py
+++ b/popper/generate.py
@@ -103,8 +103,8 @@ class Generator:
         self.new_ground_cons = set()
 
         encoding = []
-        alan = resources.files(__name__).joinpath("lp/alan-old.pl").read_text()
-        # alan = resources.files(__name__).joinpath("lp/alan.pl").read_text()
+        alan = resources.files(__package__).joinpath("lp/alan-old.pl").read_text()
+        # alan = resources.files(__package__).joinpath("lp/alan.pl").read_text()
         encoding.append(alan)
 
         with open(settings.bias_file) as f:

--- a/popper/generate.py
+++ b/popper/generate.py
@@ -7,7 +7,7 @@ import clingo
 import operator
 import numbers
 import clingo.script
-import pkg_resources
+from importlib import resources
 from collections import defaultdict
 from . util import rule_is_recursive, Constraint, Literal, format_rule, remap_variables
 clingo.script.enable_python()
@@ -103,8 +103,8 @@ class Generator:
         self.new_ground_cons = set()
 
         encoding = []
-        alan = pkg_resources.resource_string(__name__, "lp/alan-old.pl").decode()
-        # alan = pkg_resources.resource_string(__name__, "lp/alan.pl").decode()
+        alan = resources.files(__name__).joinpath("lp/alan-old.pl").read_text()
+        # alan = resources.files(__name__).joinpath("lp/alan.pl").read_text()
         encoding.append(alan)
 
         with open(settings.bias_file) as f:

--- a/popper/tester.py
+++ b/popper/tester.py
@@ -1,6 +1,6 @@
 import os
 import time
-import pkg_resources
+from importlib import resources
 from janus_swi import query_once, consult
 from functools import cache
 from contextlib import contextmanager
@@ -24,7 +24,7 @@ class Tester():
 
         bk_pl_path = self.settings.bk_file
         exs_pl_path = self.settings.ex_file
-        test_pl_path = pkg_resources.resource_filename(__name__, "lp/test.pl")
+        test_pl_path = str(resources.files(__name__).joinpath("lp/test.pl"))
 
         if not settings.pi_enabled:
             consult('prog', f':- dynamic {settings.head_literal.predicate}/{len(settings.head_literal.arguments)}.')

--- a/popper/tester.py
+++ b/popper/tester.py
@@ -24,7 +24,7 @@ class Tester():
 
         bk_pl_path = self.settings.bk_file
         exs_pl_path = self.settings.ex_file
-        test_pl_path = str(resources.files(__name__).joinpath("lp/test.pl"))
+        test_pl_path = str(resources.files(__package__).joinpath("lp/test.pl"))
 
         if not settings.pi_enabled:
             consult('prog', f':- dynamic {settings.head_literal.predicate}/{len(settings.head_literal.arguments)}.')


### PR DESCRIPTION
Hi everyone,

I tried to install Popper and noticed that it depends on `pkg_resources` which has been deprecated in version 82.0.0 of `setuptools` (see [release notes](https://setuptools.pypa.io/en/latest/history.html#v82-0-0)).

 The recommended fix is to replace `pkg_resources` with `importlib.resources` which I did here. Alternatively, fixing `setuptools` to a version below 82 (I tried 69) also works.