### PR TITLE
Parameterised MDL cost function

### DIFF
--- a/popper/combiner_mdl.py
+++ b/popper/combiner_mdl.py
@@ -440,7 +440,7 @@ class CombinerMDL:
         #             if r1 < r2:
         #                 encoding.append([-r1, -r2])  # hard clause
 
-        if last_combine_stage or not self.settings.nuwls:
+        if not self.settings.nuwls:
             _, model = maxsat.exact_maxsat_solve(encoding, soft_clauses, weights)
         else:
             _, model = maxsat.anytime_maxsat_solve(encoding, soft_clauses, weights, self.settings.anytime_timeout)

--- a/popper/combiner_mdl.py
+++ b/popper/combiner_mdl.py
@@ -13,11 +13,8 @@ from pysat.formula import IDPool
 from . import stats
 from . import logger
 from bitarray.util import subset, any_and, ones, zeros, count_and, count_or
-from . util import rule_is_recursive, prog_is_recursive, prog_has_invention, calc_prog_size, format_prog, reduce_prog, calc_rule_size, print_incomplete_solution
+from . util import rule_is_recursive, prog_is_recursive, prog_has_invention, calc_prog_size, format_prog, reduce_prog, calc_rule_size, print_incomplete_solution, mdl_score
 from . state import update_best_hypothesis
-
-POS_EXAMPLE_WEIGHT = 1
-NEG_EXAMPLE_WEIGHT = 1
 
 class SetCoverProgressPrinter(cp_model.CpSolverSolutionCallback):
     def __init__(self, rule_vars, fn_vars, fp_vars, num_pos, num_neg,
@@ -195,6 +192,9 @@ class CombinerMDL:
 
         incompatible = defaultdict(set)
 
+        # MDL cost weights: cost = a*size + b*fn + c*fp
+        a, b, c = self.settings.size_weight, self.settings.fn_weight, self.settings.fp_weight
+
         progs = list(self.saved_progs)
 
         for i in range(len(progs)):
@@ -203,7 +203,7 @@ class CombinerMDL:
             neg1 = self.coverage_neg[h1]
             size1, tp1, fp1 = self.scores[h1]
 
-            gain1 = tp1 - fp1 - size1
+            gain1 = b * tp1 - c * fp1 - a * size1
 
             for j in range(i + 1, len(progs)):
                 h2 = progs[j]
@@ -211,14 +211,14 @@ class CombinerMDL:
                 neg2 = self.coverage_neg[h2]
                 size2, tp2, fp2 = self.scores[h2]
 
-                gain2 = tp2 - fp2 - size2
+                gain2 = b * tp2 - c * fp2 - a * size2
 
                 # --- UNION COVERAGE ---
                 tp_union = count_or(pos1, pos2)
                 fp_union = count_or(neg1, neg2)
                 size_union = size1 + size2
 
-                gain_union = tp_union - fp_union - size_union
+                gain_union = b * tp_union - c * fp_union - a * size_union
 
                 # --- BASIC INCOMPATIBILITY CONDITION ---
                 if gain_union <= max(gain1, gain2):
@@ -229,16 +229,18 @@ class CombinerMDL:
         return incompatible
 
     def decide_whether_to_combine(self, prog, prog_size, test_result):
+        # MDL cost weights: cost = a*size + b*fn + c*fp
+        a, b, c = self.settings.size_weight, self.settings.fn_weight, self.settings.fp_weight
         pos_covered, neg_covered = test_result.pos_covered, test_result.neg_covered
         tp, fn, fp, tn =  test_result.tp, test_result.fn, test_result.fp, test_result.tn
         inconsistent = test_result.inconsistent
 
         best_mdl = self.state.best_hypothesis_mdl if self.state.best_hypothesis_mdl else float('inf')
-        if (fp+ prog_size) >= best_mdl:
-            print(fp + prog_size, best_mdl, format_prog(prog))
+        if (c * fp + a * prog_size) >= best_mdl:
+            print(c * fp + a * prog_size, best_mdl, format_prog(prog))
             assert(False)
         # IF A RULE COSTS MORE (SIZE + ERRORS) THAN THE POSITIVES IT COVERS, IT IS DEAD WEIGHT
-        if tp <= (fp + prog_size):
+        if b * tp <= (c * fp + a * prog_size):
             assert(False)
 
         local_delete = set()
@@ -276,7 +278,7 @@ class CombinerMDL:
                         continue
 
                     # @AC, what is this? is it sound?
-                    if (tp - fp - prog_size) <= (tp1 - fp1 - size1):
+                    if (b * tp - c * fp - a * prog_size) <= (b * tp1 - c * fp1 - a * size1):
                         ignore_this_prog = True
                         break
 
@@ -332,12 +334,12 @@ class CombinerMDL:
     def filter_combine_programs(self, to_combine_set):
         xs = self.saved_progs | to_combine_set
         min_sz = min(self.scores[prog][0] for prog in xs)
-        must_beat = self.state.best_hypothesis_mdl - min_sz
+        must_beat = self.state.best_hypothesis_mdl - self.settings.size_weight * min_sz
 
         to_delete = set()
         for prog_hash in xs:
             size, tp, fp = self.scores[prog_hash]
-            if fp + size >= must_beat:
+            if self.settings.fp_weight * fp + self.settings.size_weight * size >= must_beat:
                 to_delete.add(prog_hash)
                 continue
 
@@ -390,7 +392,7 @@ class CombinerMDL:
 
             # Soft clause: Reward the solver for NOT picking the rule (minimises size)
             soft_clauses.append([-k])
-            weights.append(size)
+            weights.append(self.settings.size_weight * size)
 
         # 2. ENCODE POSITIVE EXAMPLES (Minimise FN)
         for ex in range(num_pos):
@@ -411,7 +413,7 @@ class CombinerMDL:
 
             # Soft clause: Reward the solver for covering the positive example
             soft_clauses.append([pvar])
-            weights.append(POS_EXAMPLE_WEIGHT)
+            weights.append(self.settings.fn_weight)
 
         # 3. ENCODE NEGATIVE EXAMPLES (Minimise FP)
         for ex in range(num_neg):
@@ -422,7 +424,7 @@ class CombinerMDL:
 
             # Soft clause: Reward the solver for NOT covering the negative example
             soft_clauses.append([-nvar])
-            weights.append(NEG_EXAMPLE_WEIGHT)
+            weights.append(self.settings.fp_weight)
 
         # if trick:
         #     incompatible = self.build_incompatibility()
@@ -457,7 +459,7 @@ class CombinerMDL:
         fp = sum(1 for ex in range(num_neg) if model[N + num_pos + ex] > 0)
 
         # Calculate the actual MDL Score
-        mdl = (POS_EXAMPLE_WEIGHT * fn) + (NEG_EXAMPLE_WEIGHT * fp) + best_size
+        mdl = mdl_score(fn, fp, best_size, self.settings.fn_weight, self.settings.fp_weight, self.settings.size_weight)
         mdl_ = self.state.best_hypothesis_mdl if self.state.best_hypothesis_mdl else float('inf')
 
         # Ensure this new model is strictly better than the global best
@@ -490,6 +492,12 @@ class CombinerMDL:
 
         if not last_combine_stage:
             solver.parameters.max_time_in_seconds = self.settings.anytime_timeout
+        else:
+            # the final combine stage was previously unbounded; with a weighted MDL the cost bound
+            # is larger, so the exact proof of optimality can run long past the overall timeout.
+            # cap it by the time left in the overall budget (>=1s) so Popper always terminates -
+            # the progress callback keeps the best solution found so far.
+            solver.parameters.max_time_in_seconds = self.state.time_remaining(self.settings.timeout)
 
         printer = SetCoverProgressPrinter(
             rule_vars=rule_vars,
@@ -585,10 +593,12 @@ class CombinerMDL:
             for r_var in [rule_vars[k] for k in rules_covering_neg[j]]:
                 model.AddImplication(r_var, fp_vars[j])
 
+        # MDL cost weights: cost = a*size + b*fn + c*fp
+        a, b, c = self.settings.size_weight, self.settings.fn_weight, self.settings.fp_weight
         objective_terms = (
-            [rule_vars[k] * ruleid_to_size[k] for k in range(1, N + 1)]
-            + fn_vars
-            + fp_vars
+            [rule_vars[k] * (a * ruleid_to_size[k]) for k in range(1, N + 1)]
+            + [v * b for v in fn_vars]
+            + [v * c for v in fp_vars]
         )
         total_mdl_expr = cp_model.LinearExpr.Sum(objective_terms)
 
@@ -716,14 +726,14 @@ class CombinerMDL:
         for rule_id in rule_var:
             if rule_var[rule_id] is not None:
                 soft_clauses.append([-rule_var[rule_id]])
-                weights.append(ruleid_to_size[rule_id])
+                weights.append(self.settings.size_weight * ruleid_to_size[rule_id])
         for i in pos_index:
             soft_clauses.append([pos_example_covered_var[i]])
-            weights.append(POS_EXAMPLE_WEIGHT)
+            weights.append(self.settings.fn_weight)
 
         for i in neg_index:
             soft_clauses.append([-neg_example_covered_var[i]])
-            weights.append(NEG_EXAMPLE_WEIGHT)
+            weights.append(self.settings.fp_weight)
 
         # PRUNE INCONSISTENT
         for prog in self.inconsistent:
@@ -766,7 +776,7 @@ class CombinerMDL:
             size = sum([ruleid_to_size[rule_id] for rule_id in ruleid_to_size if model[rule_var[rule_id]-1] > 0])
 
             if self.state.best_hypothesis_score:
-                if mdl_ <= POS_EXAMPLE_WEIGHT * fn + NEG_EXAMPLE_WEIGHT * fp + size:
+                if mdl_ <= mdl_score(fn, fp, size, self.settings.fn_weight, self.settings.fp_weight, self.settings.size_weight):
                     break
 
             model_found = True
@@ -799,7 +809,7 @@ class CombinerMDL:
                 encoding.append(clause)
 
         best_prog = [ruleid_to_rule[k] for k in best_prog]
-        return best_prog, best_fn + best_fp + best_size
+        return best_prog, mdl_score(best_fn, best_fp, best_size, self.settings.fn_weight, self.settings.fp_weight, self.settings.size_weight)
 
     def greedy_upper_bound(self):
         covered_pos = zeros(self.tester.num_pos)
@@ -818,7 +828,7 @@ class CombinerMDL:
                 new_fp = count_and(~covered_neg, self.coverage_neg[h])
                 size, tp, fp = self.scores[h]
 
-                delta = size + new_fp - new_tp
+                delta = self.settings.size_weight * size + self.settings.fp_weight * new_fp - self.settings.fn_weight * new_tp
 
                 if best is None or delta < best_delta:
                     best = h
@@ -838,7 +848,7 @@ class CombinerMDL:
         fp = covered_neg.count(1)
 
         mdl_limit = self.state.best_hypothesis_mdl if self.state.best_hypothesis_mdl else float('inf')
-        prog_mdl = int(total_size + fp + fn)
+        prog_mdl = int(mdl_score(fn, fp, total_size, self.settings.fn_weight, self.settings.fp_weight, self.settings.size_weight))
 
         if prog_mdl >= mdl_limit:
             return False

--- a/popper/loop.py
+++ b/popper/loop.py
@@ -1,6 +1,6 @@
 import time
 from bitarray.util import ones
-from . util import format_rule, rule_is_recursive, prog_is_recursive, prog_has_invention, calc_prog_size, format_literal, GENERALISATION, SPECIALISATION, UNSAT, REDUNDANCY_CONSTRAINT1, REDUNDANCY_CONSTRAINT2, TMP_ANDY, BANISH, mdl_score, canonicalise, format_prog
+from . util import format_rule, rule_is_recursive, prog_is_recursive, prog_has_invention, calc_prog_size, format_literal, GENERALISATION, SPECIALISATION, UNSAT, REDUNDANCY_CONSTRAINT1, REDUNDANCY_CONSTRAINT2, TMP_ANDY, BANISH, mdl_score, ceil_div, canonicalise, format_prog
 from . tester import Tester
 from . bkcons import get_bk_cons
 from . unsat import UnsatCoreFinder
@@ -57,7 +57,7 @@ def popper(settings):
     noisy = settings.noisy
 
     if noisy:
-        initialise_noisy_best_hypothesis(state, num_pos, num_neg)
+        initialise_noisy_best_hypothesis(settings, state, num_pos, num_neg)
         build_constraints = build_constraints_noisy
         test_prog = tester.test_prog_noisy
     else:
@@ -253,6 +253,8 @@ def build_constraints_noisy(settings, tester, state, unsatcore_finder, allsatcor
     too_few_tp, too_many_fp = test_result.too_few_tp, test_result.too_many_fp
     num_pos, num_neg = tester.num_pos, tester.num_neg
     tp, fn, fp, tn = test_result.tp, test_result.fn, test_result.fp, test_result.tn
+    # MDL cost weights: cost = a*size + b*fn + c*fp
+    a, b, c = settings.size_weight, settings.fn_weight, settings.fp_weight
     # seen_hyp_spec, seen_hyp_gen = state.seen_hyp_spec, state.seen_hyp_gen
     new_cons = []
     pruned_more_general = False
@@ -286,7 +288,7 @@ def build_constraints_noisy(settings, tester, state, unsatcore_finder, allsatcor
         add_gen = True
 
     # if the program does not cover any positive examples, check whether it has an unsat core
-    if not has_invention and (tp < state.min_pos_coverage or tp <= prog_size):
+    if not has_invention and (tp < state.min_pos_coverage or b * tp <= a * prog_size):
         with stats.duration('find mucs'):
             cons_ = tuple(unsatcore_finder.explain_incomplete(prog))
             new_cons.extend(cons_)
@@ -301,11 +303,11 @@ def build_constraints_noisy(settings, tester, state, unsatcore_finder, allsatcor
             add_spec = True
             noisy_subsumed = True
 
-    if tp <= prog_size:
+    if b * tp <= a * prog_size:
         add_spec = True
 
     if not too_few_tp:
-        spec_size_ = min([tp, fp + prog_size])
+        spec_size_ = min([ceil_div(b * tp, a), prog_size + ceil_div(c * fp, a)])
         if spec_size_ <= prog_size:
             add_spec = True
         elif len(prog) == 1 and spec_size_ < settings.max_body + 1 and spec_size_ < state.max_literals:
@@ -314,13 +316,16 @@ def build_constraints_noisy(settings, tester, state, unsatcore_finder, allsatcor
             spec_size = spec_size_
 
     if too_few_tp or too_many_fp:
-        gen_size_ = fn + prog_size
+        # generalising can save at most b*fn by covering the remaining positives, worth a*extra literals
+        gen_size_ = prog_size + ceil_div(b * fn, a)
         if gen_size_ <= prog_size:
             add_gen = True
         if gen_size_ < state.max_literals:
             gen_size = gen_size_
     else:
-        gen_size_ = min([fn + prog_size, num_pos - fp, state.best_hypothesis_mdl - mdl + num_pos + prog_size])
+        gen_size_ = min([prog_size + ceil_div(b * fn, a),
+                         ceil_div(b * num_pos - c * fp, a),
+                         ceil_div(state.best_hypothesis_mdl - mdl + b * num_pos + a * prog_size, a)])
         if gen_size_ <= prog_size:
             add_gen = True
         if gen_size_ < state.max_literals:
@@ -365,7 +370,7 @@ def build_constraints_noisy(settings, tester, state, unsatcore_finder, allsatcor
     if not add_spec and not add_gen:
         new_cons.append((BANISH, prog))
 
-    add_to_combiner = (not too_few_tp) and (not too_many_fp) and (not is_recursive) and (not has_invention) and tp > prog_size + fp and fp + prog_size < state.best_hypothesis_mdl and (not noisy_subsumed)
+    add_to_combiner = (not too_few_tp) and (not too_many_fp) and (not is_recursive) and (not has_invention) and b * tp > a * prog_size + c * fp and c * fp + a * prog_size < state.best_hypothesis_mdl and (not noisy_subsumed)
 
     return new_cons, add_to_combiner
 

--- a/popper/state.py
+++ b/popper/state.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 import time
-from . util import print_incomplete_solution, mdl_score
+from . util import print_incomplete_solution, mdl_score, ceil_div
 
 class SearchState:
     def __init__(self):
@@ -35,15 +35,15 @@ class SearchState:
         time_spent = time_now - self._start_time
         return max(int(timeout-time_spent), 1)
 
-def initialise_noisy_best_hypothesis(state, num_pos, num_neg):
+def initialise_noisy_best_hypothesis(settings, state, num_pos, num_neg):
     state.best_hypothesis_score = (0, num_pos, num_neg, 0)
-    state.best_hypothesis_mdl = num_pos
+    state.best_hypothesis_mdl = settings.fn_weight * num_pos
 
 def _update_search_bounds(settings, state, hypothesis_size, conf_matrix, mdl):
     _, fn, _, fp = conf_matrix
 
     if settings.noisy:
-        state.max_literals = mdl - 1
+        state.max_literals = ceil_div(mdl, settings.size_weight) - 1
         return
 
     if fp != 0 or fn != 0:
@@ -92,7 +92,7 @@ def update_best_hypothesis(settings, state, hypothesis, hypothesis_size, conf_ma
 
     mdl = None
     if settings.noisy:
-        mdl = mdl_score(fn, fp, hypothesis_size)
+        mdl = mdl_score(fn, fp, hypothesis_size, settings.fn_weight, settings.fp_weight, settings.size_weight)
 
     if not _is_better_hypothesis(settings, state, hypothesis_size, conf_matrix, mdl):
         return

--- a/popper/tester.py
+++ b/popper/tester.py
@@ -3,7 +3,7 @@ from importlib import resources
 from janus_swi import query_once, consult
 from functools import cache, lru_cache
 from contextlib import contextmanager
-from . util import order_prog, prog_is_recursive, rule_is_recursive, calc_rule_size, calc_prog_size, get_raw_prog, format_rule, Literal, mdl_score, order_rule, canonicalise_prog_hash
+from . util import order_prog, prog_is_recursive, rule_is_recursive, calc_rule_size, calc_prog_size, get_raw_prog, format_rule, Literal, mdl_score, ceil_div, order_rule, canonicalise_prog_hash
 from . bkcons import deduce_neg_example_recalls
 from bitarray import frozenbitarray
 from bitarray.util import ones, zeros
@@ -190,7 +190,7 @@ class Tester():
         if not too_few_tp:
             fp = neg_covered.count(1)
             tn = self.num_neg - fp
-            mdl = mdl_score(fn, fp, prog_size)
+            mdl = mdl_score(fn, fp, prog_size, self.settings.fn_weight, self.settings.fp_weight, self.settings.size_weight)
 
         return TestResult(
             tp=tp,

--- a/popper/util.py
+++ b/popper/util.py
@@ -37,6 +37,9 @@ def parse_args():
     parser.add_argument('--max-body', type=int, default=None, help=f'Maximum number of body literals allowed in rule (default: {MAX_BODY})')
     parser.add_argument('--max-vars', type=int, default=None, help=f'Maximum number of variables allowed in rule (default: {MAX_VARS})')
     parser.add_argument('--nuwls', default=False, action='store_true', help='Use nuwls solver (default: False)')
+    parser.add_argument('--size-weight', type=int, default=1, help='Weight of the program size in the MDL cost function (default: 1, noisy mode only)')
+    parser.add_argument('--fn-weight', type=int, default=1, help='Weight of false negatives in the MDL cost function; increase to favour recall/general programs (default: 1, noisy mode only)')
+    parser.add_argument('--fp-weight', type=int, default=1, help='Weight of false positives in the MDL cost function; increase to favour precision/specific programs (default: 1, noisy mode only)')
     parser.add_argument('-v', action='count', default=1, dest='verbosity', help='Increase verbosity (-v, -vv, or -vvv)')
     parser.add_argument('-j', dest='joiner', default=False, action='store_true', help=argparse.SUPPRESS)
     return parser.parse_args()
@@ -105,8 +108,12 @@ def rule_is_invented(rule):
     head_pred, _head_arg = head
     return head_pred.startswith('inv')
 
-def mdl_score(fn, fp, size):
-    return fn + fp + size
+def ceil_div(a: int, b: int) -> int:
+    # ceiling of a / b for integers, b > 0 (works for negative a too)
+    return -(-a // b)
+
+def mdl_score(fn, fp, size, fn_weight=1, fp_weight=1, size_weight=1):
+    return fn_weight * fn + fp_weight * fp + size_weight * size
 
 def get_body_preds(solver):
     body_preds_ = set()
@@ -131,7 +138,17 @@ class Settings:
         settings = Settings(**conf)
         return settings
 
-    def __init__(self, timeout=TIMEOUT, max_body=MAX_BODY, max_vars=MAX_VARS, ex_file=None, bk_file=None, bias_file=None, noisy=False, nuwls=None, anytime_timeout=ANYTIME_TIMEOUT, verbosity=1, joiner=False, all_opt=False, max_body_override=False, max_vars_override=False, **kwargs):
+    def __init__(self, timeout=TIMEOUT, max_body=MAX_BODY, max_vars=MAX_VARS, ex_file=None, bk_file=None, bias_file=None, noisy=False, nuwls=None, anytime_timeout=ANYTIME_TIMEOUT, verbosity=1, joiner=False, all_opt=False, size_weight=1, fn_weight=1, fp_weight=1, max_body_override=False, max_vars_override=False, **kwargs):
+
+        # weights of the MDL cost function: size_weight*size + fn_weight*fn + fp_weight*fp (noisy mode only).
+        # must be positive integers: the cost is fed to integer (Max)SAT/CP solvers and the search-pruning
+        # bounds divide by these weights (see ceil_div usages in tester/loop/state).
+        for name, value in (('size_weight', size_weight), ('fn_weight', fn_weight), ('fp_weight', fp_weight)):
+            if not isinstance(value, int) or value < 1:
+                raise ValueError(f'{name} must be a positive integer, got {value!r}')
+        self.size_weight = size_weight
+        self.fn_weight = fn_weight
+        self.fp_weight = fp_weight
 
         self.all_opt = all_opt
         self.joiner = joiner
@@ -551,7 +568,8 @@ def print_incomplete_solution(prog, size, conf_matrix, settings, noisy: bool):
     logger.out('*'*20)
     logger.out('New best hypothesis:')
     if noisy:
-        logger.out(f'tp:{tp} fn:{fn} tn:{tn} fp:{fp} size:{size} mdl:{size+fn+fp}')
+        mdl = mdl_score(fn, fp, size, settings.fn_weight, settings.fp_weight, settings.size_weight)
+        logger.out(f'tp:{tp} fn:{fn} tn:{tn} fp:{fp} size:{size} mdl:{mdl}')
     else:
         logger.out(f'tp:{tp} fn:{fn} tn:{tn} fp:{fp} size:{size}')
     for rule in order_prog(prog):
@@ -569,7 +587,8 @@ def print_prog_score(prog, score, settings, noisy: bool):
         recall = f'{tp / (tp+fn):0.2f}'
     logger.out('*'*10 + ' SOLUTION ' + '*'*10)
     if noisy:
-        logger.out(f'Precision:{precision} Recall:{recall} TP:{tp} FN:{fn} TN:{tn} FP:{fp} Size:{size} MDL:{size+fn+fp}')
+        mdl = mdl_score(fn, fp, size, settings.fn_weight, settings.fp_weight, settings.size_weight)
+        logger.out(f'Precision:{precision} Recall:{recall} TP:{tp} FN:{fn} TN:{tn} FP:{fp} Size:{size} MDL:{mdl}')
     else:
         logger.out(f'Precision:{precision} Recall:{recall} TP:{tp} FN:{fn} TN:{tn} FP:{fp} Size:{size}')
     for rule in order_prog(prog):


### PR DESCRIPTION
closes #143 

This PR adds 3 command line parameters to Popper that are only relevant if the `--noisy` flag is set:
- ` size-weight` increases the impact of program size on the total cost
- `fp-weight` increases the impact of false positives
- `fn-weight` increases the impact of false negatives

I also tried to adjust the various heuristics that are influenced by the weights, but I am not sure if I got all of them right.

## Potential issues

### Heuristic in `tester.py`
The tester has some condition based on the number of TPs vs. program size. This should probably get weighted, but I'm not sure what the intention of this condition is:

https://github.com/logic-and-learning-lab/Popper/blob/a4f3eb1690237bdfc491f8c9a8d2477aa3b419c1/popper/tester.py#L161-L166 

### Timeout in `combiner_mdl.py`
The combiner only applies the anytime timeout if `last_combine_stage` is false. This leads to Popper not terminating properly if `fn-weight` is set. My understanding is that the solver suddenly has to look at far larger rules to determine whether they make a minimal improvement in the number of FNs.

https://github.com/logic-and-learning-lab/Popper/blob/a4f3eb1690237bdfc491f8c9a8d2477aa3b419c1/popper/combiner_mdl.py#L441-L444

https://github.com/logic-and-learning-lab/Popper/blob/a4f3eb1690237bdfc491f8c9a8d2477aa3b419c1/popper/combiner_mdl.py#L491-L492

I tested this for the `noisy-zendo2-10` task with a timeout of 30 seconds. With NuWLS, Popper terminated after ~90s. With CPSAT, Popper didn't terminate within 400s. For now, I have removed the exemption for the last combine stage.

## Results on `noisy-zendo2-10`
I tested this for the `noisy-zendo2-10` example.
The results are as you would expect - `size-weight` gives you shorter rules, `fp-weight` gives you better precision, `fn-weight` better recall.

Below are the commands and solutions:
Standard MDL:
```
python popper.py examples/noisy-zendo2-10 --noisy --timeout 30 --nuwls 

40.5s ********** SOLUTION **********
40.5s Precision:0.90 Recall:0.91 TP:90 FN:9 TN:91 FP:10 Size:14 MDL:33
40.5s zendo(V0):- piece(V0,V1),green(V1),piece(V0,V2),blue(V2),piece(V0,V3),red(V3).
40.5s zendo(V0):- piece(V0,V1),green(V1),coord1(V1,V3),piece(V0,V2),lhs(V2),coord1(V2,V3).
40.5s ******************************
```
With size weight:
```
python popper.py examples/noisy-zendo2-10 --noisy --timeout 30 --nuwls --seize-weight 10

4.5s ********** SOLUTION **********
4.5s Precision:0.61 Recall:0.96 TP:95 FN:4 TN:40 FP:61 Size:3 MDL:95
4.5s zendo(V0):- piece(V0,V1),green(V1).
4.5s ******************************
```
With FP weight:
```
python popper.py examples/noisy-zendo2-10 --noisy --timeout 30 --nuwls --fp-weight 10

32.5s ********** SOLUTION **********
32.5s Precision:1.00 Recall:0.53 TP:52 FN:47 TN:101 FP:0 Size:23 MDL:70
32.5s zendo(V0):- piece(V0,V1),green(V1),rhs(V1),piece(V0,V2),lhs(V2),green(V2).
32.5s zendo(V0):- piece(V0,V1),red(V1),piece(V0,V2),blue(V2),piece(V0,V3),upright(V3),green(V3).
32.5s zendo(V0):- large(V3),piece(V0,V1),lhs(V1),size(V1,V3),piece(V0,V2),size(V2,V3),green(V2).
32.5s ******************************
```
With FN weight:
```
python popper.py examples/noisy-zendo2-10 --noisy --timeout 30 --nuwls --fn-weight 10

44.6s ********** SOLUTION **********
44.6s Precision:0.80 Recall:1.00 TP:99 FN:0 TN:77 FP:24 Size:33 MDL:57
44.6s zendo(V0):- medium(V2),piece(V0,V1),rhs(V1),blue(V1),size(V1,V2).
44.6s zendo(V0):- piece(V0,V1),upright(V1),piece(V0,V2),lhs(V2),red(V2).
44.6s zendo(V0):- piece(V0,V1),green(V1),coord1(V1,V3),piece(V0,V2),lhs(V2),coord1(V2,V3).
44.6s zendo(V0):- piece(V0,V1),strange(V1),coord1(V1,V3),size(V1,V3),piece(V0,V2),rhs(V2).
44.6s zendo(V0):- piece(V0,V1),green(V1),piece(V0,V2),red(V2),piece(V0,V3),blue(V3).
44.6s ******************************
```